### PR TITLE
Add Income categories

### DIFF
--- a/Expenso/Configs.swift
+++ b/Expenso/Configs.swift
@@ -30,7 +30,7 @@ let CURRENCY_LIST = ["₹", "$", "€", "¥", "£", "¢", "₭"]
 let TRANS_TYPE_INCOME = "income"
 let TRANS_TYPE_EXPENSE = "expense"
 
-// Transaction tags
+// Expense Transaction tags
 let TRANS_TAG_TRANSPORT = "transport"
 let TRANS_TAG_FOOD = "food"
 let TRANS_TAG_HOUSING = "housing"
@@ -39,11 +39,20 @@ let TRANS_TAG_MEDICAL = "medical"
 let TRANS_TAG_SAVINGS = "savings"
 let TRANS_TAG_PERSONAL = "personal"
 let TRANS_TAG_ENTERTAINMENT = "entertainment"
-let TRANS_TAG_OTHERS = "others"
 let TRANS_TAG_UTILITIES = "utilities"
+
+// Income Transaction tags
+let TRANS_TAG_SALARY = "salary"
+let TRANS_TAG_CASHBACK = "cashback"
+let TRANS_TAG_INVESTMENT_RETURNS = "investment_returns"
+let TRANS_TAG_SALE = "sale"
+
+// Common Transaction tags
+let TRANS_TAG_OTHERS = "others"
 
 func getTransTagIcon(transTag: String) -> String {
     switch transTag {
+        // Expenses
         case TRANS_TAG_TRANSPORT: return "trans_type_transport"
         case TRANS_TAG_FOOD: return "trans_type_food"
         case TRANS_TAG_HOUSING: return "trans_type_housing"
@@ -52,14 +61,22 @@ func getTransTagIcon(transTag: String) -> String {
         case TRANS_TAG_SAVINGS: return "trans_type_savings"
         case TRANS_TAG_PERSONAL: return "trans_type_personal"
         case TRANS_TAG_ENTERTAINMENT: return "trans_type_entertainment"
-        case TRANS_TAG_OTHERS: return "trans_type_others"
         case TRANS_TAG_UTILITIES: return "trans_type_utilities"
+        
+        // Incomes
+        // TODO: Add icon sets for every income tag
+        case TRANS_TAG_SALARY: return "trans_type_savings"
+        case TRANS_TAG_CASHBACK: return "trans_type_savings"
+        case TRANS_TAG_INVESTMENT_RETURNS: return "trans_type_savings"
+        case TRANS_TAG_SALE: return "trans_type_savings"
+        
         default: return "trans_type_others"
     }
 }
 
 func getTransTagTitle(transTag: String) -> String {
     switch transTag {
+        // Expenses
         case TRANS_TAG_TRANSPORT: return "Transport"
         case TRANS_TAG_FOOD: return "Food"
         case TRANS_TAG_HOUSING: return "Housing"
@@ -68,8 +85,17 @@ func getTransTagTitle(transTag: String) -> String {
         case TRANS_TAG_SAVINGS: return "Savings"
         case TRANS_TAG_PERSONAL: return "Personal"
         case TRANS_TAG_ENTERTAINMENT: return "Entertainment"
-        case TRANS_TAG_OTHERS: return "Others"
         case TRANS_TAG_UTILITIES: return "Utilities"
+        
+        // Incomes
+        case TRANS_TAG_SALARY: return "Salary"
+        case TRANS_TAG_CASHBACK: return "Cashback"
+        case TRANS_TAG_INVESTMENT_RETURNS: return "Investment Returns"
+        case TRANS_TAG_SALE: return "Sale"
+        
+        // Common
+        case TRANS_TAG_OTHERS: return "Others"
+        
         default: return "Unknown"
     }
 }

--- a/Expenso/Screens/AddExpense/AddExpenseView.swift
+++ b/Expenso/Screens/AddExpense/AddExpenseView.swift
@@ -22,7 +22,7 @@ struct AddExpenseView: View {
         DropdownOption(key: TRANS_TYPE_EXPENSE, val: "Expense")
     ]
     
-    let tagOptions = [
+    let expenseTagOptions = [
         DropdownOption(key: TRANS_TAG_TRANSPORT, val: "Transport"),
         DropdownOption(key: TRANS_TAG_FOOD, val: "Food"),
         DropdownOption(key: TRANS_TAG_HOUSING, val: "Housing"),
@@ -33,6 +33,14 @@ struct AddExpenseView: View {
         DropdownOption(key: TRANS_TAG_ENTERTAINMENT, val: "Entertainment"),
         DropdownOption(key: TRANS_TAG_OTHERS, val: "Others"),
         DropdownOption(key: TRANS_TAG_UTILITIES, val: "Utilities")
+    ]
+    
+    let incomeTagOptions = [
+        DropdownOption(key: TRANS_TAG_SALARY, val: "Salary"),
+        DropdownOption(key: TRANS_TAG_CASHBACK, val: "Cashback"),
+        DropdownOption(key: TRANS_TAG_INVESTMENT_RETURNS, val: "Investment Returns"),
+        DropdownOption(key: TRANS_TAG_OTHERS, val: "Others"),
+        DropdownOption(key: TRANS_TAG_SALE, val: "Sale"),
     ]
     
     var body: some View {
@@ -88,8 +96,10 @@ struct AddExpenseView: View {
                             }
                             
                             DropdownButton(shouldShowDropdown: $viewModel.showTagDrop, displayText: $viewModel.tagTitle,
-                                           options: tagOptions, mainColor: Color.text_primary_color,
-                                           backgroundColor: Color.secondary_color, cornerRadius: 4, buttonHeight: 50) { key in
+                                           options: viewModel.selectedType == TRANS_TYPE_INCOME ? incomeTagOptions : expenseTagOptions,
+                                           mainColor: Color.text_primary_color, backgroundColor: Color.secondary_color,
+                                           cornerRadius: 4, buttonHeight: 50) { key in
+                                let tagOptions = viewModel.selectedType == TRANS_TYPE_INCOME ? incomeTagOptions : expenseTagOptions
                                 let selectedObj = tagOptions.filter({ $0.key == key }).first
                                 if let object = selectedObj {
                                     viewModel.tagTitle = object.val

--- a/Expenso/Screens/AddExpense/AddExpenseViewModel.swift
+++ b/Expenso/Screens/AddExpense/AddExpenseViewModel.swift
@@ -16,13 +16,13 @@ class AddExpenseViewModel: ObservableObject {
     @Published var amount = ""
     @Published var occuredOn = Date()
     @Published var note = ""
-    @Published var typeTitle = "Income"
-    @Published var tagTitle = getTransTagTitle(transTag: TRANS_TAG_TRANSPORT)
+    @Published var typeTitle = "Expense"
+    @Published var tagTitle = getTransTagTitle(transTag: TRANS_TAG_OTHERS)
     @Published var showTypeDrop = false
     @Published var showTagDrop = false
     
-    @Published var selectedType = TRANS_TYPE_INCOME
-    @Published var selectedTag = TRANS_TAG_TRANSPORT
+    @Published var selectedType = TRANS_TYPE_EXPENSE
+    @Published var selectedTag = TRANS_TAG_OTHERS
     
     @Published var imageUpdated = false // When transaction edit, check if attachment is updated?
     @Published var imageAttached: UIImage? = nil
@@ -40,13 +40,13 @@ class AddExpenseViewModel: ObservableObject {
             self.typeTitle = expenseObj.type == TRANS_TYPE_INCOME ? "Income" : "Expense"
         } else {
             self.amount = ""
-            self.typeTitle = "Income"
+            self.typeTitle = "Expense"
         }
         self.occuredOn = expenseObj?.occuredOn ?? Date()
         self.note = expenseObj?.note ?? ""
-        self.tagTitle = getTransTagTitle(transTag: expenseObj?.tag ?? TRANS_TAG_TRANSPORT)
-        self.selectedType = expenseObj?.type ?? TRANS_TYPE_INCOME
-        self.selectedTag = expenseObj?.tag ?? TRANS_TAG_TRANSPORT
+        self.tagTitle = getTransTagTitle(transTag: expenseObj?.tag ?? TRANS_TAG_OTHERS)
+        self.selectedType = expenseObj?.type ?? TRANS_TYPE_EXPENSE
+        self.selectedTag = expenseObj?.tag ?? TRANS_TAG_OTHERS
         if let data = expenseObj?.imageAttached {
             self.imageAttached = UIImage(data: data)
         }


### PR DESCRIPTION
Fixes https://github.com/sameersyd/Expenso-iOS/issues/31 by adding separate categories for incomes.

IMO users should be able to add/customise their own categories without needing to update code, but we can do it later if the maintainers of this project would be interested in it. :)

I've not added any new icons yet. I can add them if the code looks good. Also, because I'm not sure what would be good icons for these new tags.

![IMG_35AC3D1A287A-1](https://user-images.githubusercontent.com/3167291/195999249-3ce4889c-a7e6-4703-b94e-e25307b0789d.jpeg)